### PR TITLE
APT-3321 BUGFIX: Unreliable Matching

### DIFF
--- a/.github/workflows/python_venv.sh
+++ b/.github/workflows/python_venv.sh
@@ -15,30 +15,9 @@
 # limitations under the License.
 
 # Use as:
-# build.sh [CMake arguments]
+# source python_venv.sh
 
-set -e
-
-cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
-
-source ./python_venv.sh
-
-export CC=${CC:-"gcc"}
-if [ -z "${CXX:-}" ]; then
-    case "${CC}" in
-        gcc)
-            export CXX=g++
-            ;;
-        clang)
-            export CXX=clang++
-            ;;
-        *)
-            ;;
-    esac
+# If the Python virtual environment is there, activate it to avoid "error: externally-managed-environment"
+if [ -d "/tmp/provizio_dds.venv" ]; then
+    source /tmp/provizio_dds.venv/bin/activate
 fi
-
-mkdir -p ../../build
-cd ../../build
-
-cmake .. $@
-cmake --build . -- -j 16

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -18,6 +18,8 @@ set -e
 
 cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
+source ./python_venv.sh
+
 # Source ROS, if present
 for ROS_DIR in /opt/ros/* ; do
     if [[ -f "${ROS_DIR}/setup.bash" ]]; then

--- a/.github/workflows/test_pip_package.sh
+++ b/.github/workflows/test_pip_package.sh
@@ -18,7 +18,11 @@ set -e
 
 cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
-source ./python_venv.sh
+# Make (or re-make) and activate a test Python virtual environment
+VENV=/tmp/provizio_dds_test_pip_package.venv
+rm -rf ${VENV}
+python3 -m venv ${VENV}
+source ${VENV}/bin/activate
 
 export CC=${CC:-"gcc"}
 if [ -z "${CXX:-}" ]; then
@@ -37,7 +41,7 @@ fi
 cd ../../
 
 # Build and install the package
-pip3 install -v .
+python3 -m pip install -v .
 
 # Test it works fine by executing Python tests directly (without copying provizio_dds.py and other beside the tests)
 python3 test/python/python_publisher.py & python3 test/python/python_subscriber.py

--- a/.github/workflows/test_pip_package.sh
+++ b/.github/workflows/test_pip_package.sh
@@ -18,6 +18,8 @@ set -e
 
 cd $(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
+source ./python_venv.sh
+
 export CC=${CC:-"gcc"}
 if [ -z "${CXX:-}" ]; then
     case "${CC}" in

--- a/.github/workflows/test_pip_package.sh
+++ b/.github/workflows/test_pip_package.sh
@@ -24,6 +24,13 @@ rm -rf ${VENV}
 python3 -m venv ${VENV}
 source ${VENV}/bin/activate
 
+# Manually install some dependencies in older versions of Python to avoid known incompatibilities in numpy and Cython
+python3 -m pip install wheel
+python_version=$(python -c 'import sys; print("".join(map(str, sys.version_info[:2])))')
+if [[ "${python_version}" -lt "390" ]]; then
+    python3 -m pip install "Cython<3" "numpy"
+fi
+
 export CC=${CC:-"gcc"}
 if [ -z "${CXX:-}" ]; then
     case "${CC}" in
@@ -46,3 +53,7 @@ python3 -m pip install -v .
 # Test it works fine by executing Python tests directly (without copying provizio_dds.py and other beside the tests)
 python3 test/python/python_publisher.py & python3 test/python/python_subscriber.py
 python3 test/python/pointcloud2_test.py
+
+# Deactivate and delete the virtual environment
+deactivate
+rm -rf ${VENV}

--- a/.github/workflows/test_pip_package.sh
+++ b/.github/workflows/test_pip_package.sh
@@ -25,9 +25,9 @@ python3 -m venv ${VENV}
 source ${VENV}/bin/activate
 
 # Manually install some dependencies in older versions of Python to avoid known incompatibilities in numpy and Cython
-python3 -m pip install wheel
-python_version=$(python -c 'import sys; print("".join(map(str, sys.version_info[:2])))')
-if [[ "${python_version}" -lt "390" ]]; then
+python3 -m pip install wheel setuptools
+python_version=$(python3 -c 'import sys; print("".join(map(str, sys.version_info[:2])))')
+if [[ "${python_version}" -lt "39" ]]; then
     python3 -m pip install "Cython<3" "numpy"
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+Testing/
 .vscode/
 .clang-format
 .clang-tidy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,8 +322,15 @@ if(PYTHON_BINDINGS)
 
     # Make sure Fast-DDS is built prior to SWIG code generation
     if(FAST_DDS_DEPENDENCIES)
-        add_dependencies(fastdds_python_swig_compilation ${FAST_DDS_DEPENDENCIES})
-        add_dependencies(provizio_dds_python_types_swig_compilation ${FAST_DDS_DEPENDENCIES})
+        if(TARGET fastdds_python_swig_compilation)
+            # Older versions of CMake
+            add_dependencies(fastdds_python_swig_compilation ${FAST_DDS_DEPENDENCIES})
+            add_dependencies(provizio_dds_python_types_swig_compilation ${FAST_DDS_DEPENDENCIES})
+        else(TARGET fastdds_python_swig_compilation)
+            # Newer versions of CMake
+            add_dependencies(fastdds_python ${FAST_DDS_DEPENDENCIES})
+            add_dependencies(provizio_dds_python_types ${FAST_DDS_DEPENDENCIES})
+        endif(TARGET fastdds_python_swig_compilation)
     endif(FAST_DDS_DEPENDENCIES)
 
     set(FASTDDS_PYTHON_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ include(FetchContent)
 
 # Configuration
 set(PROVIZIO_DDS_IDLS_VERSION "master" CACHE STRING "provizio_dds_idls version")
-set(FAST_DDS_VERSION "v2.8.2" CACHE STRING "Fast-DDS version, when not already present in the system")
+set(FAST_DDS_VERSION "v2.11.2" CACHE STRING "Fast-DDS version, when not already present in the system")
 set(LOOK_FOR_FAST_DDS TRUE CACHE BOOL "Try to find Fast-DDS installation, and only build one when not found")
-set(FOONATHAN_MEMORY_VENDOR_VERSION "v1.3.0" CACHE STRING "provizio_dds_idls foonathan_memory_vendor version")
+set(FOONATHAN_MEMORY_VENDOR_VERSION "v1.3.1" CACHE STRING "provizio_dds_idls foonathan_memory_vendor version")
 set(FAST_DDS_PYTHON_VERSION "1.2.1" CACHE STRING "Fast-DDS-python version, without v prefix")
 set(PROVIZIO_CODING_STANDARDS_VERSION "v23.04.20" CACHE STRING "Provizio Coding Standards version")
 set(FORMAT_CMAKE_VERSION "1.7.3" CACHE STRING "Provizio Format.cmake version, without v prefix")

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -26,7 +26,8 @@ INSTALL_ROS=${3:-"OFF"}
 FAST_DDS_INSTALL=${4:-"OFF"}
 CC=${CC:-"gcc"}
 
-FAST_DDS_VERSION=${FAST_DDS_VERSION:-v2.10.1}
+FAST_DDS_VERSION=${FAST_DDS_VERSION:-v2.11.2}
+FAST_CDR_VERSION=${FAST_CDR_VERSION:-v1.1.1}
 
 if [[ "${OSTYPE}" == "darwin"* ]]; then
   # macOS
@@ -87,6 +88,12 @@ else
     exit 1
   fi
 
+  # Update apt cache
+  apt update
+
+  # Install lsb-release for checking Ubuntu version and accessing https
+  apt install -y --no-install-recommends lsb-release ca-certificates
+
   # Check if running in Ubuntu 18
   UBUNTU_18=false
   if lsb_release -a | grep -q 18; then
@@ -100,12 +107,6 @@ else
     echo "Running in Ubuntu 20 detected..."
     UBUNTU_20=true
   fi
-
-  # Update apt cache
-  apt update
-
-  # Install lsb-release for checking Ubuntu version
-  apt install -y --no-install-recommends lsb-release
 
   # Install GCC/clang
   if [[ "${CC}" == "gcc" ]]; then
@@ -174,8 +175,10 @@ else
       # Fast CDR
       cd /tmp/fastdds
       git clone https://github.com/eProsima/Fast-CDR.git
-      mkdir Fast-CDR/build
-      cd Fast-CDR/build
+      cd Fast-CDR
+      git checkout ${FAST_CDR_VERSION}
+      mkdir build
+      cd build
       cmake .. -DCMAKE_INSTALL_PREFIX="${FAST_DDS_INSTALL}" -DBUILD_SHARED_LIBS=ON
       cmake --build . --target install
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -58,7 +58,7 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   if [[ "${PYTHON}" != "OFF" ]]; then
     # Install Python and related dependencies
     brew install python3
-    pip3 install setuptools
+    python3 -m pip install setuptools
 
     # Install SWIG
     brew install swig
@@ -224,8 +224,8 @@ else
 
   if [[ "${PYTHON}" != "OFF" ]]; then
     # Install Python and related dependencies
-    apt install -y --no-install-recommends python3 python3-pip libpython3-dev
-    pip3 install setuptools
+    apt install -y --no-install-recommends python3 python3-pip python3-venv libpython3-dev
+    python3 -m pip install setuptools
 
     # Install SWIG
     if [ "${UBUNTU_18}" = true ]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -61,6 +61,9 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
 
     # Install SWIG
     brew install swig
+
+    # Make a virtual environment to avoid "error: externally-managed-environment"
+    python3 -m venv /tmp/provizio_dds.venv
   fi
 
   if [[ "${STATIC_ANALYSIS}" != "OFF" ]]; then

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -58,13 +58,16 @@ if [[ "${OSTYPE}" == "darwin"* ]]; then
   if [[ "${PYTHON}" != "OFF" ]]; then
     # Install Python and related dependencies
     brew install python3
-    python3 -m pip install setuptools
+    python3 -m pip install wheel setuptools
 
     # Install SWIG
     brew install swig
 
     # Make a virtual environment to avoid "error: externally-managed-environment"
     python3 -m venv /tmp/provizio_dds.venv
+    source /tmp/provizio_dds.venv/bin/activate
+    python3 -m pip install wheel setuptools
+    deactivate
   fi
 
   if [[ "${STATIC_ANALYSIS}" != "OFF" ]]; then

--- a/python/provizio_dds.py
+++ b/python/provizio_dds.py
@@ -79,8 +79,13 @@ def make_domain_participant(domain_id: int = 0):
     class _DomainParticipant:
         def __init__(self, domain_id):
             factory = DomainParticipantFactory.get_instance()
+
             self._participant_qos = DomainParticipantQos()
             factory.get_default_participant_qos(self._participant_qos)
+            # More reliable matching
+            self._participant_qos.wire_protocol(
+            ).builtin.discovery_config.initial_announcements.count = 150
+            
             self._participant = factory.create_participant(
                 domain_id, self._participant_qos)
 

--- a/src/domain_participant.cpp
+++ b/src/domain_participant.cpp
@@ -30,8 +30,15 @@ namespace provizio
 
         std::shared_ptr<DomainParticipant> make_domain_participant(DomainId_t domain_id)
         {
-            return {dds::DomainParticipantFactory::get_instance()->create_participant(domain_id,
-                                                                                      PARTICIPANT_QOS_DEFAULT, nullptr),
+            auto qos = PARTICIPANT_QOS_DEFAULT;
+
+            // More reliable matching (only 5 multicast announcements are sent 0.1 seconds apart by default, which is
+            // often not enough when nearing 100% bandwidth load)
+            constexpr std::uint32_t num_initial_discovery_announcements = 150;
+            qos.wire_protocol().builtin.discovery_config.initial_announcements.count =
+                num_initial_discovery_announcements;
+
+            return {dds::DomainParticipantFactory::get_instance()->create_participant(domain_id, qos, nullptr),
                     delete_participant};
         }
     } // namespace dds

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -50,3 +50,8 @@ add_test(NAME python_subscriber_no_leaks_test
     COMMAND sh -c "\"${PYTHON_EXECUTABLE}\" -q -X faulthandler ./python_subscriber_no_leaks_test.py"
     WORKING_DIRECTORY "${TEST_PATH}"
 )
+
+add_test(NAME python_stop_subscriber_test
+    COMMAND sh -c "\"${PYTHON_EXECUTABLE}\" -q -X faulthandler ./python_stop_subscriber_test.py"
+    WORKING_DIRECTORY "${TEST_PATH}"
+)

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -40,3 +40,13 @@ add_test(NAME pointcloud2_test
     COMMAND sh -c "\"${PYTHON_EXECUTABLE}\" -q -X faulthandler ./pointcloud2_test.py"
     WORKING_DIRECTORY "${TEST_PATH}"
 )
+
+add_test(NAME python_publisher_no_leaks_test
+    COMMAND sh -c "\"${PYTHON_EXECUTABLE}\" -q -X faulthandler ./python_publisher_no_leaks_test.py"
+    WORKING_DIRECTORY "${TEST_PATH}"
+)
+
+add_test(NAME python_subscriber_no_leaks_test
+    COMMAND sh -c "\"${PYTHON_EXECUTABLE}\" -q -X faulthandler ./python_subscriber_no_leaks_test.py"
+    WORKING_DIRECTORY "${TEST_PATH}"
+)

--- a/test/python/python_publisher_no_leaks_test.py
+++ b/test/python/python_publisher_no_leaks_test.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Provizio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""
+Simple test DDS publisher written in Python
+"""
+import sys
+import provizio_dds
+import gc
+
+TEST_TOPIC_NAME = "provizio_dds_test_python_publisher_no_leaks_"
+TEST_VALUE = "test message #"
+PUBLISH_TIMES = 25
+
+num_objects_after_the_first_publish = 0
+message = provizio_dds.String()
+for i in range(PUBLISH_TIMES):
+    message.data(TEST_VALUE + str(i))
+    publisher = provizio_dds.Publisher(
+        provizio_dds.make_domain_participant(), TEST_TOPIC_NAME + str(i), provizio_dds.StringPubSubType, lambda _, has_subscriber: print(has_subscriber))
+    del publisher
+    gc.collect()
+
+    num_objects_now = len(gc.get_objects())
+    if i == 0:
+        num_objects_after_the_first_publish = num_objects_now
+    else:
+        if num_objects_now > num_objects_after_the_first_publish:
+            print(
+                f"There seems to be a leak: number of objects in gc increased by {num_objects_now - num_objects_after_the_first_publish}")
+            sys.exit(1)
+
+print("python_publisher_no_leaks_test: No leaks detected!")
+sys.exit(0)

--- a/test/python/python_stop_subscriber_test.py
+++ b/test/python/python_stop_subscriber_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Provizio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""
+Checks stopping a subscriber works as expected
+"""
+import sys
+import provizio_dds
+import threading
+import time
+import os
+import signal
+
+TEST_TOPIC_NAME = "provizio_dds_python_stop_subscriber_test"
+TEST_VALUE = "test"
+MAX_WAIT_TIME = 5
+RECEIVE_NUM_TIMES = 10
+PUBLISH_EVERY_SEC = 0.02
+
+pid = os.fork()
+if pid > 0:
+    # Subscriber
+    times_received = 0
+    had_publishers = False
+    cv = threading.Condition()
+
+    def on_message(_):
+        """Callback to be invoked on receiving a message"""
+        with cv:
+            global times_received
+            times_received += 1
+            cv.notify_all()
+
+
+    def on_has_publisher_changed_function(has):
+        if (has):
+            with cv:
+                global had_publishers
+                had_publishers = True
+                cv.notify_all()
+
+    subscriber = provizio_dds.Subscriber(
+        provizio_dds.make_domain_participant(), TEST_TOPIC_NAME, provizio_dds.StringPubSubType, provizio_dds.String, on_message, on_has_publisher_changed_function)
+
+    with cv:
+        cv.wait_for(
+            lambda: had_publishers and times_received >= RECEIVE_NUM_TIMES, MAX_WAIT_TIME)
+        times_received_was = times_received
+
+    # Make sure it kept publishing
+    time.sleep(RECEIVE_NUM_TIMES * PUBLISH_EVERY_SEC)
+    del subscriber  # So we're sure received_string won't be modified anymore
+
+    with cv:
+        if times_received_was == times_received:
+            print("Stopped publishing too soon")
+            sys.exit(1)
+        times_received_was = times_received
+
+    # It kept publishing some more, but we're not receiving anything anymore
+    time.sleep(RECEIVE_NUM_TIMES * PUBLISH_EVERY_SEC)
+    with cv:
+        if times_received_was != times_received:
+            print("Somehow kept receiving after being deleted!")
+            sys.exit(1)
+
+        if (not had_publishers):
+            print("subscriber: never matched a publisher")
+            sys.exit(1)
+
+        if (times_received < RECEIVE_NUM_TIMES):
+            print(
+                f"subscriber: received just {times_received} messages while {RECEIVE_NUM_TIMES} was expected!")
+            sys.exit(1)
+
+    os.kill(pid, signal.SIGTERM)
+    print("Success!")
+else:
+    # Publisher
+    publisher = provizio_dds.Publisher(provizio_dds.make_domain_participant(), TEST_TOPIC_NAME, provizio_dds.StringPubSubType)
+
+    message = provizio_dds.String()
+    message.data(TEST_VALUE)
+
+    stop_flag = False
+    def stop():
+        global stop_flag
+        stop_flag = True
+
+    signal.signal(signal.SIGINT, lambda *_: stop())
+
+    while not stop_flag:
+        publisher.publish(message)
+        time.sleep(PUBLISH_EVERY_SEC)

--- a/test/python/python_stop_subscriber_test.py
+++ b/test/python/python_stop_subscriber_test.py
@@ -27,7 +27,7 @@ TEST_TOPIC_NAME = "provizio_dds_python_stop_subscriber_test"
 TEST_VALUE = "test"
 MAX_WAIT_TIME = 5
 RECEIVE_NUM_TIMES = 10
-PUBLISH_EVERY_SEC = 0.02
+PUBLISH_EVERY_SEC = 0.05
 
 pid = os.fork()
 if pid > 0:

--- a/test/python/python_subscriber_no_leaks_test.py
+++ b/test/python/python_subscriber_no_leaks_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright 2023 Provizio Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+"""
+Simple test DDS publisher written in Python
+"""
+import sys
+import provizio_dds
+import gc
+
+TEST_TOPIC_NAME = "provizio_dds_test_python_subscriber_no_leaks_"
+PUBLISH_TIMES = 25
+
+num_objects_after_the_first_subscriber = 0
+for i in range(PUBLISH_TIMES):
+    subscriber = provizio_dds.Subscriber(
+        provizio_dds.make_domain_participant(), TEST_TOPIC_NAME + str(i), provizio_dds.StringPubSubType, provizio_dds.String, lambda data: print(data), lambda has_publisher: print(has_publisher))
+    del subscriber
+    gc.collect()
+
+    num_objects_now = len(gc.get_objects())
+    if i == 0:
+        num_objects_after_the_first_subscriber = num_objects_now
+    else:
+        if num_objects_now > num_objects_after_the_first_subscriber:
+            print(
+                f"There seems to be a leak: number of objects in gc increased by {num_objects_now - num_objects_after_the_first_subscriber}")
+            sys.exit(1)
+
+print("python_subscriber_no_leaks_test: No leaks detected!")
+sys.exit(0)

--- a/test/ros_interop/ros_interop_subscriber/ros_interop_subscriber.cpp
+++ b/test/ros_interop/ros_interop_subscriber/ros_interop_subscriber.cpp
@@ -46,16 +46,20 @@ int main()
         },
         reliability_kind);
 
-    std::unique_lock<std::mutex> lock{mutex};
-    condition_variable.wait_for(lock, wait_time,
-                                [&]() { return string.substr(0, expected_substring.length()) == expected_substring; });
-
-    if (string.substr(0, expected_substring.length()) != expected_substring)
     {
-        std::cerr << expected_substring << "* was expected but " << (string.empty() ? "nothing" : string)
-                  << " was received!" << std::endl;
-        return 1;
+        std::unique_lock<std::mutex> lock{mutex};
+        condition_variable.wait_for(
+            lock, wait_time, [&]() { return string.substr(0, expected_substring.length()) == expected_substring; });
+
+        if (string.substr(0, expected_substring.length()) != expected_substring)
+        {
+            std::cerr << expected_substring << "* was expected but " << (string.empty() ? "nothing" : string)
+                      << " was received!" << std::endl;
+            return 1;
+        }
     }
+
+    std::cout << "ros_interop_subscriber: Success" << std::endl;
 
     return 0;
 }

--- a/test/simplest_pub_sub/simplest_subscriber/simplest_subscriber.cpp
+++ b/test/simplest_pub_sub/simplest_subscriber/simplest_subscriber.cpp
@@ -36,14 +36,16 @@ int main()
             condition_variable.notify_one();
         });
 
-    std::unique_lock<std::mutex> lock{mutex};
-    condition_variable.wait_for(lock, wait_time, [&]() { return string == expected_value; });
-
-    if (string != expected_value)
     {
-        std::cerr << "simplest_subscriber: " << expected_value << " was expected but "
-                  << (string.empty() ? "nothing" : string) << " was received!" << std::endl;
-        return 1;
+        std::unique_lock<std::mutex> lock{mutex};
+        condition_variable.wait_for(lock, wait_time, [&]() { return string == expected_value; });
+
+        if (string != expected_value)
+        {
+            std::cerr << "simplest_subscriber: " << expected_value << " was expected but "
+                      << (string.empty() ? "nothing" : string) << " was received!" << std::endl;
+            return 1;
+        }
     }
 
     std::cout << "simplest_subscriber: Success" << std::endl;


### PR DESCRIPTION
At least one related bug is fixed: due to leaking of C++ SWIG-wrapped objects in Python wrapper of provizio_dds, publishers could be stockpiling, and when exceeding some numbers (different in different tries, may depend on network bandwidth), newly created publishers fail to match or fail to publish to DDS subscribers. It's due to a limitation of Python when dealing with native (C/C++) code: when Python classes extend C++ classes (wrapped as Python classes using SWIG), then they can't be part of looped references, otherwise Python garbage collector can never clean them up, even when calling `del <object_name>`  and `gc.collect()` directly. It's not that easily reproduced when both publisher and subscriber are on the same machine (hence not detected in unit tests before) likely because with shared memory it can handle much higher numbers publishers & subscribers coexisting.

To test it, you can do the following:
1. Copy (and extract) the attached subscriber test script:
[test_subscriber.zip](https://github.com/provizio/provizio_dds/files/13121881/test_subscriber.zip)
to one machine, and the attached publisher test script:
[test_publisher.zip](https://github.com/provizio/provizio_dds/files/13121883/test_publisher.zip)
to another on the same network.

2. Install "master" version of Python provizio_dds in both machines (first removing the previously installed version, if any):
`python3 -m pip uninstall provizio_dds`
`python3 -m pip install -v git+https://github.com/provizio/provizio_dds.git`

3. Run (quickly enoughm, f.e. over SSH) both the publisher and subscriber, as
`python3 test_publisher.py`
`python3 test_subscriber.py`

4. After some tries it first starts to fail to deliver messages to the subscriber, and then may fail to match (and even crash, on exhausting memory)

5. Now install the fixed version of provizio_dds (first removing the previously installed version):
`python3 -m pip uninstall provizio_dds`
`python3 -m pip install -v git+https://github.com/provizio/provizio_dds.git@feature/APT-3321-Bugfix-Unreliable-Matching`

6. Run the same test as in 3).

7. Wait long enough, the progress will be seen in the output on both side as test numbers (1..10000). If all is fine, it should successfully match and deliver test messages in all 10000 tries on both sides:

```
test_publisher: Successfully matched #10000!
test_publisher: Published #0!
test_publisher: on_has_subscriber False
test_publisher: Successfully unmatched #10000!
```

Please also note, that 2 new unit tests have been added to make sure it doesn't happen - they specifically catch memory leaks in Python both publisher and subscriber. I tried using "master" version of provizio_dds with them and then fixed one, and it works as expected: older one fails with detected memory leaks in the Python publisher, while the new one passes fine.


Additionally, by default Fast DDS does 5 connection tries 0.1 seconds apart each. Then every nodes just passively listens to new connections to be advertised. So in case of just 0.5 seconds connection issue (or busy router, like, with a Pandar on the network) and both participants starting at close time, they would fail to discover each other. I made it 150 tries instead (same 0.1 seconds apart), so it can tolerate up to 15 seconds connectivity issues on start, and also provides much higher chance of at least one advertisement UDP packet to be delivered even in busy networks. I did appropriate tests and see huge improvement in reliability of participants matching.