### PR TITLE
Fix bin cache softlinks for 4-component Fast-DDS 3 library names

### DIFF
--- a/fully_qualified_fastdds_libs.sh
+++ b/fully_qualified_fastdds_libs.sh
@@ -33,9 +33,15 @@ if [[ "${REVERT}" == "revert" ]]; then
     for file in "${LIB_DIR_TO_PATCH}"/libfast*.so.*.*.*; do
         if [[ ! -L "${file}" ]]; then
             file_basename="$(basename "${file}")"
-            ln -fs "${file_basename}" "${LIB_DIR_TO_PATCH}/${file_basename%.*}" #.so.x.y
-            ln -fs "${file_basename}" "${LIB_DIR_TO_PATCH}/${file_basename%.*.*}" #.so.x
-            ln -fs "${file_basename}" "${LIB_DIR_TO_PATCH}/${file_basename%.*.*.*}" #.so
+            # Create the whole chain of softlinks down to the unversioned .so,
+            # whatever the number of version components: Fast-DDS 2 libs use
+            # 3 (e.g. libfastrtps.so.2.10.1) while Fast-DDS 3 libs use 4
+            # (e.g. libfastdds.so.3.6.2.0)
+            link_name="${file_basename}"
+            while [[ "${link_name}" == *.so.* ]]; do
+                link_name="${link_name%.*}"
+                ln -fs "${file_basename}" "${LIB_DIR_TO_PATCH}/${link_name}"
+            done
             echo "Softlinks added for ${file_basename}"
         fi
     done


### PR DESCRIPTION
## Bug

`fully_qualified_fastdds_libs.sh` (revert mode) creates the unversioned/partial softlinks for cached Fast-DDS libs by stripping exactly **three** version components — correct for Fast-DDS 2 names (`libfastrtps.so.2.10.1`), wrong for Fast-DDS 3's **four-component** `libfastdds.so.3.6.2.0`: the chain stops at `libfastdds.so.3` and `libfastdds.so` is never created. Any consumer building provizio_dds via ExternalProject with the bin cache then fails at link time:

```
/usr/bin/ld: cannot find -lfastdds
```

First observed in packaging_and_deployment CI (Build CAN / Build Radar AI Perception jobs) the moment those consumers enabled the bin cache — previously masked because ExternalProject consumers either built from source (apt_gui, `IGNORE_BIN_CACHE=ON`) or resolved provizio_dds via Conan.

## Fix

Strip version components iteratively down to `.so`, whatever their count. Verified:
- Unit: `libfastdds.so.3.6.2.0` → `.so.3.6.2`, `.so.3.6`, `.so.3`, `.so`; `libfastcdr.so.2.3.5` behavior unchanged.
- End-to-end on 2.0.1 cache mode (x86_64): pristine configure reproduces the missing `libfastdds.so` in the unpacked cache; with the fixed script the full softlink chain lands in the ExternalProject `install/lib` via the existing `install(DIRECTORY)` — `-lfastdds` resolves.

## Release note

The bin cache config name embeds the repo contents hash, so this change invalidates the committed cache zips — regenerate them (build_cache flow) before tagging. Suggested tag: **2.0.2**, after which packaging_and_deployment and the pending dds-2.0.1 consumer branches (provizio_can#31, apt_dsp#159, ai_perception_microservices_cpp#26) bump their pinned/default version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)