### PR TITLE
build: add FORCE_BIN_CACHE to use the prebuilt cache on older-kernel hosts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ if(PYTHON_PACKAGES_INSTALL_DIR)
     string(REPLACE "\\" "/" PYTHON_PACKAGES_INSTALL_DIR "${PYTHON_PACKAGES_INSTALL_DIR}")
 endif()
 set(IGNORE_BIN_CACHE OFF CACHE BOOL "Enable to force build from sources instead of using prebuilt cache")
+set(FORCE_BIN_CACHE OFF CACHE BOOL "Use the prebuilt cache even when it was built on a newer Linux kernel than the host (the cached libraries are userspace and kernel-version independent); also honoured via the FORCE_BIN_CACHE environment variable")
 set(DONT_INSTALL_STDCPP_LIBS ON CACHE BOOL "When installing from prebuilt binaries, skip standard C++ libraries")
 set(INSTALL_ONLY_FULLY_QUALIFIED_FAST_DDS_LIBS OFF CACHE BOOL "Install and link to fully-qualified Fast-DDS libraries to avoid runtime incompatibilities across different .so.major.minor.patch versions, Linux only")
 set(DISABLE_EIGEN OFF CACHE BOOL "Force plain-CPU linear algebra in point clouds accumulation for this build even when Eigen3 is installed (consumers make their own choice at compile time — the accumulation maths path is header-only)")
@@ -159,17 +160,30 @@ if(NOT IGNORE_BIN_CACHE AND(NOT DEFINED ENV{IGNORE_BIN_CACHE} OR "$ENV{IGNORE_BI
         if(EXISTS "${CACHED_PROVIZIO_DDS_SO}" AND(NOT PYTHON_BINDINGS OR EXISTS "${CACHED_PROVIZIO_DDS_PYTHON_TYPES_SO}"))
             execute_process(COMMAND uname -r OUTPUT_VARIABLE HOST_KERNEL_VERSION)
             file(READ "${BIN_CACHE_PATH}/kernel_version" CACHE_KERNEL_VERSION)
-            if("${HOST_KERNEL_VERSION}" VERSION_GREATER_EQUAL "${CACHE_KERNEL_VERSION}")
+            # The prebuilt cache is normally only used when the host kernel is at
+            # least as new as the kernel it was built on. The cached libraries are
+            # pure userspace (Fast DDS / Fast CDR over sockets + shared memory) and
+            # do not depend on the build kernel's version, so FORCE_BIN_CACHE (CMake
+            # option or environment variable) lets hosts whose kernel lags the CI
+            # cache-build kernel still use the prebuilt binaries.
+            if(FORCE_BIN_CACHE OR (DEFINED ENV{FORCE_BIN_CACHE} AND NOT "$ENV{FORCE_BIN_CACHE}" STREQUAL "FALSE"))
+                set(USE_BIN_CACHE TRUE)
+                message(STATUS "FORCE_BIN_CACHE set: using prebuilt binaries regardless of the cache build kernel (${CACHE_KERNEL_VERSION})")
+            elseif("${HOST_KERNEL_VERSION}" VERSION_GREATER_EQUAL "${CACHE_KERNEL_VERSION}")
+                set(USE_BIN_CACHE TRUE)
+            else()
+                set(USE_BIN_CACHE FALSE)
+                message(STATUS "Prebuilt binaries located, but won't be used as they were built in a newer Linux kernel (set FORCE_BIN_CACHE=ON to override)")
+            endif()
+
+            if(USE_BIN_CACHE)
                 set(HAS_BIN_CACHE TRUE)
 
                 if(NOT INSTALL_ONLY_FULLY_QUALIFIED_FAST_DDS_LIBS)
                     # Softlinks need to be added, as cache doesn't include them
                     execute_process(COMMAND "${CMAKE_CURRENT_SOURCE_DIR}/fully_qualified_fastdds_libs.sh" "${BIN_CACHE_PATH}/lib" "revert")
                 endif(NOT INSTALL_ONLY_FULLY_QUALIFIED_FAST_DDS_LIBS)
-
-            else("${HOST_KERNEL_VERSION}" VERSION_GREATER_EQUAL "${CACHE_KERNEL_VERSION}")
-                message(STATUS "Prebuilt binaries located, but won't be used as they were built in a newer Linux kernel")
-            endif("${HOST_KERNEL_VERSION}" VERSION_GREATER_EQUAL "${CACHE_KERNEL_VERSION}")
+            endif()
         endif(EXISTS "${CACHED_PROVIZIO_DDS_SO}" AND(NOT PYTHON_BINDINGS OR EXISTS "${CACHED_PROVIZIO_DDS_PYTHON_TYPES_SO}"))
     elseif(WIN32)
         # Find PowerShell

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,15 +158,19 @@ if(NOT IGNORE_BIN_CACHE AND(NOT DEFINED ENV{IGNORE_BIN_CACHE} OR "$ENV{IGNORE_BI
         endif(PYTHON_VERSION_TAG AND EXISTS "${PYTHON_BIN_CACHE_SOURCE_PATH}" AND NOT EXISTS "${CACHED_PROVIZIO_DDS_PYTHON_TYPES_SO}")
 
         if(EXISTS "${CACHED_PROVIZIO_DDS_SO}" AND(NOT PYTHON_BINDINGS OR EXISTS "${CACHED_PROVIZIO_DDS_PYTHON_TYPES_SO}"))
-            execute_process(COMMAND uname -r OUTPUT_VARIABLE HOST_KERNEL_VERSION)
+            execute_process(COMMAND uname -r OUTPUT_VARIABLE HOST_KERNEL_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
             file(READ "${BIN_CACHE_PATH}/kernel_version" CACHE_KERNEL_VERSION)
+            string(STRIP "${CACHE_KERNEL_VERSION}" CACHE_KERNEL_VERSION)
             # The prebuilt cache is normally only used when the host kernel is at
             # least as new as the kernel it was built on. The cached libraries are
             # pure userspace (Fast DDS / Fast CDR over sockets + shared memory) and
             # do not depend on the build kernel's version, so FORCE_BIN_CACHE (CMake
             # option or environment variable) lets hosts whose kernel lags the CI
             # cache-build kernel still use the prebuilt binaries.
-            if(FORCE_BIN_CACHE OR (DEFINED ENV{FORCE_BIN_CACHE} AND NOT "$ENV{FORCE_BIN_CACHE}" STREQUAL "FALSE"))
+            # Evaluate the env var through a normal variable so if() applies standard
+            # boolean semantics (OFF/0/FALSE/NO/empty are false; ON/1/TRUE are true).
+            set(FORCE_BIN_CACHE_ENV "$ENV{FORCE_BIN_CACHE}")
+            if(FORCE_BIN_CACHE OR FORCE_BIN_CACHE_ENV)
                 set(USE_BIN_CACHE TRUE)
                 message(STATUS "FORCE_BIN_CACHE set: using prebuilt binaries regardless of the cache build kernel (${CACHE_KERNEL_VERSION})")
             elseif("${HOST_KERNEL_VERSION}" VERSION_GREATER_EQUAL "${CACHE_KERNEL_VERSION}")


### PR DESCRIPTION
## Problem

The prebuilt binary cache is only used when the host kernel is **>=** the kernel it was built on (the `HOST_KERNEL_VERSION VERSION_GREATER_EQUAL CACHE_KERNEL_VERSION` guard). CI publishes the cache from a newer kernel than typical developer / deployment hosts, so `HOST < CACHE` is the common case and the cache is refused ("won't be used as they were built in a newer Linux kernel") — forcing a slow Fast-DDS-from-source rebuild in exactly the environments the cache should accelerate.

Observed downstream in `radar_fusion_tracker` (consumes provizio_dds via CMake `ExternalProject`):

| Host | `uname -r` | Cache kernel | Result |
|------|-----------|--------------|--------|
| CI (Azure runner) | `6.8.0-1059-azure` | `6.8.0-…` | cache used ✅ |
| Dev workstation | `5.15.0-1106-nvidia` | `6.8.0-…` | rejected → source build ❌ |
| Jetson (aarch64) | `4.9.201-tegra` | (aarch64 cache) | same, where CACHE > HOST |

The from-source fallback is also ASan-instrumented when the tree was first configured `Debug` (coding_standards defaults ASan on in Debug), which then forces `LD_PRELOAD=libasan` at runtime downstream — a second surprise from the same guard.

## Why using the cache here is safe

Fast DDS / Fast CDR / provizio_dds are pure userspace (UDP + shared memory); they do not require kernel features tied to the build kernel's version. The cache config-name hash already pins the ABI-relevant compiler / libc / platform axis. Verified: a `radar_fusion_tracker` linked against the `6.8`-built cache loads and runs correctly on a `5.15` host — no source rebuild, no ASan.

## Change

Add **`FORCE_BIN_CACHE`** (CMake option + environment variable, default **OFF** — no change to default behaviour) that bypasses the `kernel_version` comparison and uses the prebuilt cache regardless of the cache build kernel. Mirrors the existing `IGNORE_BIN_CACHE` escape hatch.

## Testing

- Extracted the guard into a standalone script and validated every branch with `cmake -P`: with the option **off** and `HOST 5.15 < CACHE 6.8` it still rejects (behaviour unchanged); `-DFORCE_BIN_CACHE=ON` and `FORCE_BIN_CACHE=ON` (env) both force cache use.
- Not run through the full provizio_dds build locally (needs the cache + Fast-DDS deps) — relying on CI for the end-to-end build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
