### PR TITLE
Fix the flaky tests and CI infra failures at their causes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,7 +438,16 @@ jobs:
     name: Test compatibility with ROS2
     runs-on: ubuntu-latest
     container:
-      image: ros:${{matrix.ros}}
+      # Pulled through Google's public mirror of Docker Hub rather than Docker Hub itself.
+      # Docker Hub rate-limits UNAUTHENTICATED pulls per source IP over an hourly window and
+      # answers a request past the limit with an immediate HTTP 429 ("toomanyrequests"), which
+      # no amount of retrying can wait out. This matrix alone pulls a ros:* image per distro per
+      # job, so it is the biggest Docker Hub surface in this workflow. mirror.gcr.io is a
+      # pull-through cache serving byte-identical content, is not subject to those limits, and
+      # needs no credentials. Set the CONTAINER_REGISTRY_PREFIX repository/organisation variable
+      # to redirect this at a registry the runners authenticate against (or back at Docker Hub,
+      # with prefix "library", if that is ever preferable).
+      image: ${{ vars.CONTAINER_REGISTRY_PREFIX || 'mirror.gcr.io/library' }}/ros:${{matrix.ros}}
       # The reliability request/response tests run a service + client (multiple Fast-DDS
       # participants) concurrently, and provizio's large-sample QoS sizes each participant's
       # shared-memory segment at ~34 MB. Docker's default 64 MB /dev/shm can't hold more than

--- a/.github/workflows/test_congested_network.sh
+++ b/.github/workflows/test_congested_network.sh
@@ -41,9 +41,62 @@ fi
 (docker container rm provizio_dds_congested_subscriber || true) >/dev/null 2>&1
 (docker network rm provizio_dds_congested_network || true) >/dev/null 2>&1
 
+# Building the images is INFRASTRUCTURE, and it fails for reasons that have nothing to do with
+# provizio_dds: a Docker Hub pull that 5xx's or hits a rate limit, an apt mirror hiccup inside
+# install_dependencies.sh, a PyPI timeout. Running the containers is the TEST, and its exit code
+# is the result -- retrying that would hide exactly the regressions this suite exists to catch.
+# So the two are split: the build retries, the run never does.
+build_images() {
+    local attempt=1
+    local delay=15
+    local log
+    log="$(mktemp)"
+    local status
+    while true; do
+        # Streamed through tee so the build stays visible live AND can be inspected below.
+        # PIPESTATUS[0] rather than the pipeline's status, which is tee's and always 0 -- reading
+        # that would treat every failed build as a success. Declared before the pipeline because
+        # any intervening command resets PIPESTATUS.
+        COMPOSE_FILE=congested_network_compose.yml docker compose --progress plain build 2>&1 | tee "${log}" || true
+        status="${PIPESTATUS[0]}"
+        if [[ "${status}" -eq 0 ]]; then
+            rm -f "${log}"
+            return 0
+        fi
+        # A registry rate limit is NOT a transient fault. Docker Hub answers a pull past its
+        # unauthenticated per-IP limit with an immediate HTTP 429, and the limit resets on an
+        # hourly window — no backoff this loop could apply will outlast it. Retrying only burns
+        # minutes and buries the real reason, so say what happened and stop. (The base image
+        # defaults to a mirror that is not subject to those limits precisely so this should not
+        # arise; see BASE_IMAGE in the dockerfile.)
+        if grep -qiE "toomanyrequests|rate limit|pull rate limit|unauthorized: authentication required" "${log}"; then
+            echo "docker compose build hit a registry rate limit or an authentication error --" \
+                 "NOT retrying, because neither clears within a build. Authenticate the runner" \
+                 "to the registry, or set BASE_IMAGE to one it can pull."
+            rm -f "${log}"
+            return 1
+        fi
+        if [[ "${attempt}" -ge "${DOCKER_BUILD_MAX_ATTEMPTS}" ]]; then
+            echo "docker compose build failed after ${DOCKER_BUILD_MAX_ATTEMPTS} attempts"
+            rm -f "${log}"
+            return 1
+        fi
+        echo "docker compose build failed (attempt ${attempt}/${DOCKER_BUILD_MAX_ATTEMPTS}); retrying in ${delay}s..."
+        sleep "${delay}"
+        delay=$((delay * 2))
+        attempt=$((attempt + 1))
+    done
+}
+
+DOCKER_BUILD_MAX_ATTEMPTS=${DOCKER_BUILD_MAX_ATTEMPTS:-3}
+if ! build_images; then
+    exit 1
+fi
+
 for (( i = 0; i <= NUM_ITERATIONS; i++ )); do
     echo "congested_network_test #${i}..."
-    if ! COMPOSE_FILE=congested_network_compose.yml docker compose --progress plain up --force-recreate --build --exit-code-from subscriber; then
+    # --no-build: the images were built (with retries) above, so a failure here is the test's.
+    if ! COMPOSE_FILE=congested_network_compose.yml docker compose --progress plain up --force-recreate --no-build --exit-code-from subscriber; then
         echo "Run #${i} failed!"
         exit 1
     fi

--- a/congested_network_compose.yml
+++ b/congested_network_compose.yml
@@ -4,6 +4,9 @@ services:
       context: .
       dockerfile: test/congested_network_test/congested_network_test.dockerfile
       args:
+        # See the BASE_IMAGE note in the dockerfile: defaults to a mirror that does not
+        # rate-limit unauthenticated pulls the way Docker Hub does.
+        BASE_IMAGE: ${BASE_IMAGE:-mirror.gcr.io/library/ubuntu:22.04}
         SERVICE: subscriber
         NETWORK_DELAY: 0ms
         PACKETS_LOSS: 0%
@@ -24,6 +27,9 @@ services:
       context: .
       dockerfile: test/congested_network_test/congested_network_test.dockerfile
       args:
+        # See the BASE_IMAGE note in the dockerfile: defaults to a mirror that does not
+        # rate-limit unauthenticated pulls the way Docker Hub does.
+        BASE_IMAGE: ${BASE_IMAGE:-mirror.gcr.io/library/ubuntu:22.04}
         SERVICE: publisher
         NETWORK_DELAY: ${NETWORK_DELAY:-150ms}
         PACKETS_LOSS: ${PACKETS_LOSS:-50%}

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -95,23 +95,67 @@ else
     exit 1
   fi
 
+  # apt on CI hosts fails transiently far more often than it fails meaningfully: a mirror
+  # returning 5xx or closing a connection mid-download, a stale package list after a mirror
+  # rotation, and — on GitHub-hosted runners — unattended-upgrades holding the dpkg lock for the
+  # first minute or two of the job. Every one of those aborts an otherwise healthy build, and
+  # this script is re-run from scratch inside the congested-network Docker image on every CI
+  # run, so it is the single largest apt surface in the project.
+  #
+  # Two layers of defence, because they cover different failures:
+  #   - Acquire::Retries makes apt itself retry an individual failed download.
+  #   - DPkg::Lock::Timeout waits for the dpkg lock instead of failing instantly. Unknown to
+  #     apt < 1.9 (Ubuntu 18.04), which ignores unrecognised -o keys, so it is safe there.
+  #   - The outer loop covers what neither does: a refreshed package list between attempts,
+  #     with exponential backoff, for the "404 on a package version" case after a rotation.
+  APT_MAX_ATTEMPTS=${APT_MAX_ATTEMPTS:-5}
+  APT_OPTIONS=(-o "Acquire::Retries=3" -o "DPkg::Lock::Timeout=180")
+
+  # apt_get <args...>: run apt-get with those options, retrying transient failures.
+  apt_get() {
+    local attempt=1
+    local delay=5
+    while true; do
+      if apt-get "${APT_OPTIONS[@]}" "$@"; then
+        return 0
+      fi
+      if [[ "${attempt}" -ge "${APT_MAX_ATTEMPTS}" ]]; then
+        echo "apt-get $* failed after ${APT_MAX_ATTEMPTS} attempts" >&2
+        return 1
+      fi
+      echo "apt-get $* failed (attempt ${attempt}/${APT_MAX_ATTEMPTS}); retrying in ${delay}s..." >&2
+      sleep "${delay}"
+      delay=$((delay * 2))
+      # A stale package list is a common cause; refresh it before trying again. Its own
+      # failure is not fatal here — the retry of the real command is what matters.
+      apt-get "${APT_OPTIONS[@]}" update || true
+      attempt=$((attempt + 1))
+    done
+  }
+
+  # apt_get_optional <args...>: same options but NO retries, for calls whose failure is an
+  # expected outcome the caller handles (e.g. a held package) rather than a transient fault.
+  apt_get_optional() {
+    apt-get "${APT_OPTIONS[@]}" "$@"
+  }
+
   # Update apt cache
-  apt update
+  apt_get update
 
   # Install lsb-release for checking Ubuntu version and accessing https
-  apt install -y --no-install-recommends lsb-release ca-certificates
+  apt_get install -y --no-install-recommends lsb-release ca-certificates
 
   # Install build-essential
-  apt install -y --no-install-recommends build-essential
+  apt_get install -y --no-install-recommends build-essential
 
   # Install patchelf
-  apt install -y --no-install-recommends patchelf
+  apt_get install -y --no-install-recommends patchelf
 
   # Install unzip
-  apt install -y --no-install-recommends unzip
+  apt_get install -y --no-install-recommends unzip
 
   # Install Eigen3 (optional provizio_dds dependency: accelerates point clouds accumulation linear algebra)
-  apt install -y --no-install-recommends libeigen3-dev
+  apt_get install -y --no-install-recommends libeigen3-dev
 
   # Check if running in Ubuntu 18
   UBUNTU_18=false
@@ -144,27 +188,27 @@ else
   # Install GCC/clang
   if [[ "${CC}" == "gcc" ]]; then
     if [ "${UBUNTU_18}" = true ]; then
-      apt install -y software-properties-common
+      apt_get install -y software-properties-common
       add-apt-repository -y ppa:ubuntu-toolchain-r/test
-      apt update
-      apt install -y --no-install-recommends gcc-9 g++-9
+      apt_get update
+      apt_get install -y --no-install-recommends gcc-9 g++-9
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 100
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 100
     else
-      apt install -y --no-install-recommends gcc g++
+      apt_get install -y --no-install-recommends gcc g++
     fi
   else
     if [ "${UBUNTU_18}" = true ]; then
-      apt install -y --no-install-recommends clang-10
+      apt_get install -y --no-install-recommends clang-10
       update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
       update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
     else
-      apt install -y --no-install-recommends clang
+      apt_get install -y --no-install-recommends clang
     fi
   fi
 
   # Install make
-  apt install -y --no-install-recommends make ninja-build
+  apt_get install -y --no-install-recommends make ninja-build
 
   # Install CMake
   if [ "${UBUNTU_18}" = true ] || [ "${UBUNTU_20}" = true ]; then
@@ -173,37 +217,37 @@ else
       else
           CMAKE_VERSION=3.25.2-0kitware1ubuntu20.04.1
       fi
-      apt install -y software-properties-common lsb-release wget
+      apt_get install -y software-properties-common lsb-release wget
       wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
       apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main"
-      apt update
-      apt install -y --no-install-recommends kitware-archive-keyring
-      apt install -y --no-install-recommends --allow-downgrades cmake=${CMAKE_VERSION} cmake-data=${CMAKE_VERSION} || echo "Skipping installing cmake, it's likely already installed and held"
+      apt_get update
+      apt_get install -y --no-install-recommends kitware-archive-keyring
+      apt_get_optional install -y --no-install-recommends --allow-downgrades cmake=${CMAKE_VERSION} cmake-data=${CMAKE_VERSION} || echo "Skipping installing cmake, it's likely already installed and held"
   else
-      apt install -y --no-install-recommends cmake
+      apt_get install -y --no-install-recommends cmake
   fi
 
   # Install git 2.18+
   if [ "${UBUNTU_18}" = true ]; then
     apt-add-repository ppa:git-core/ppa
-    apt update
+    apt_get update
   fi
-  apt install -y --no-install-recommends git
+  apt_get install -y --no-install-recommends git
 
   # Install libssl-dev
-  apt install -y --no-install-recommends libssl-dev
+  apt_get install -y --no-install-recommends libssl-dev
 
   if [[ "${STATIC_ANALYSIS}" != "OFF" ]]; then
     # Install cppcheck, clang-format and clang-tidy (and clang for proper clang-tidy checks)
     if [ "${UBUNTU_18}" = true ]; then
-      apt install -y --no-install-recommends clang-10 clang-format-10 clang-tidy-10
+      apt_get install -y --no-install-recommends clang-10 clang-format-10 clang-tidy-10
 
       update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 100
       update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 100
       update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
       update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-10 100
     else
-      apt install -y --no-install-recommends clang clang-format clang-tidy cppcheck
+      apt_get install -y --no-install-recommends clang clang-format clang-tidy cppcheck
     fi
   fi
 
@@ -214,7 +258,7 @@ else
         FAST_DDS_INSTALL="/usr/local/"
       fi
 
-      apt install -y --no-install-recommends wget python3-pip libasio-dev libtinyxml2-dev
+      apt_get install -y --no-install-recommends wget python3-pip libasio-dev libtinyxml2-dev
       rm -rf /tmp/fastdds # In case of previous installation
       mkdir /tmp/fastdds
 
@@ -265,22 +309,22 @@ else
 
     echo "Installing ROS2: ${ROS2_VERSION}..."
 
-    apt install  -y --no-install-recommends locales
+    apt_get install  -y --no-install-recommends locales
     locale-gen en_US en_US.UTF-8
     update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
     export LANG=en_US.UTF-8
-    apt install -y --no-install-recommends software-properties-common
+    apt_get install -y --no-install-recommends software-properties-common
     add-apt-repository universe
-    apt install -y --no-install-recommends curl
+    apt_get install -y --no-install-recommends curl
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-    apt update
-    apt install -y --no-install-recommends ros-${ROS2_VERSION}-desktop
+    apt_get update
+    apt_get install -y --no-install-recommends ros-${ROS2_VERSION}-desktop
   fi
 
   if [[ "${PYTHON}" != "OFF" ]]; then
     # Install Python and related dependencies
-    apt install -y --no-install-recommends python3 python3-pip python3-venv libpython3-dev python3-setuptools
+    apt_get install -y --no-install-recommends python3 python3-pip python3-venv libpython3-dev python3-setuptools
 
     # Install SWIG >= 4.4 from source (apt versions are too old or broken across Ubuntu releases)
     CURRENT_SWIG_VERSION=$(swig -version 2>/dev/null | grep -oP 'SWIG Version \K[0-9.]+' || echo "0.0.0")
@@ -290,7 +334,7 @@ else
       (
         set -eu
 
-        apt install -y --no-install-recommends wget libpcre2-dev automake bison byacc
+        apt_get install -y --no-install-recommends wget libpcre2-dev automake bison byacc
         cd /tmp
         wget -c https://github.com/swig/swig/archive/refs/tags/v${SWIG_VERSION}.tar.gz -O - | tar -xz
         cd swig-${SWIG_VERSION}

--- a/test/congested_network_test/congested_network_test.dockerfile
+++ b/test/congested_network_test/congested_network_test.dockerfile
@@ -1,4 +1,17 @@
-FROM ubuntu:22.04
+# Base image pulled through Google's public mirror of Docker Hub rather than Docker Hub
+# itself. Docker Hub rate-limits UNAUTHENTICATED pulls per source IP over an hourly window and
+# answers a request over the limit with an immediate HTTP 429 ("toomanyrequests: You have
+# reached your unauthenticated pull rate limit"). That is not a transient fault: retrying
+# cannot outlast an hourly window, so a build retry loop only wastes time and muddies the log.
+# Self-hosted runners share one egress IP across every concurrent job in the organisation,
+# which is exactly the shape that hits the limit.
+#
+# mirror.gcr.io serves byte-identical Docker Hub content (it is a pull-through cache, so
+# library/ubuntu here IS ubuntu there) and is not subject to Docker Hub's limits, and it needs
+# no credentials — so this works out of the box. Override BASE_IMAGE to point at a registry
+# the host is authenticated against (or back at Docker Hub) if that is ever preferable.
+ARG BASE_IMAGE=mirror.gcr.io/library/ubuntu:22.04
+FROM ${BASE_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -630,5 +630,32 @@ if(WIN32)
         "PATH=${PROVIZIO_DDS_TEST_PATH}")
 endif(WIN32)
 
+
+# ---------------------------------------------------------------------------------------
+# Test isolation, mirroring test/request_response/CMakeLists.txt: these entries reuse the
+# same DDS service name on the same domain (14) as each other AND as the C++ entries, so
+# they take the same locks. Under `ctest -j` without them, one test's service answers (and
+# fills its request quota from) another test's client. See the long note in
+# test/request_response/CMakeLists.txt for the measurements.
+# ---------------------------------------------------------------------------------------
+set_tests_properties(
+    cpp_service_client_python_service
+    python_request_cpp_response_concurrent_requests_serial_service
+    python_request_cpp_service
+    python_request_cpp_service_concurrent
+    python_request_response
+    python_request_response_async
+    python_request_response_concurrent_service_client
+    python_request_response_service_client
+    python_serial_service_cpp_concurrent_requests
+    python_service_client_cpp_service
+    python_service_cpp_client
+    python_service_cpp_requests_concurrent
+    PROPERTIES RESOURCE_LOCK provizio_dds_test_request_response)
+set_tests_properties(
+    python_request_response_ignore
+    python_request_response_ignore_async
+    PROPERTIES RESOURCE_LOCK provizio_dds_test_request_response_ignore)
+
 # Scale every test TIMEOUT in this directory when a sanitizer is active (no-op otherwise).
 provizio_dds_scale_test_timeouts()

--- a/test/python/python_request_response_reliability_service.py
+++ b/test/python/python_request_response_reliability_service.py
@@ -51,8 +51,16 @@ def main() -> int:
         else 14
     )
     initial_iterations = max(1, num_iterations)
-    # Match the C++ reliability service timeout (num_iterations * 3 + 30).
-    wait_timeout = num_iterations * 3.0 + 30
+    # Deadline on IDLENESS, not on total time -- matching the C++ reliability service. This
+    # service is a passive responder: its job is to notice a client that has STOPPED, not to cap
+    # how long a slow machine may take to work through the iterations. The former budget
+    # (num_iterations * 3 + 30) was sized at almost exactly the per-iteration cost the slowest CI
+    # runners actually achieve -- a jetson-20.04 run was observed at 412.8 s of its 414 s budget
+    # by iteration 120 of 128 -- so it failed on machine speed rather than on anything this test
+    # is about. Waiting instead for the gap BETWEEN requests keeps the regression signal (a client
+    # that dies or hangs is still caught, within a bounded time) while being indifferent to how
+    # slow the host is. The ctest TIMEOUT bounds the whole run regardless.
+    idle_timeout = 60.0
 
     log_prefix = f"python_request_response_reliability_service{test_name_postfix}: "
     service_name = f"provizio_dds_test_request_response_reliability{test_name_postfix}"
@@ -70,12 +78,14 @@ def main() -> int:
     condition_variable = threading.Condition()
     requests_processed = False
     received_expected_values = True
+    # Counts every request handled, so the wait below can tell a slow client from a dead one.
+    requests_received = 0
 
     domain_participant = provizio_dds.make_domain_participant(domain_id)
 
     def handle_request(request):
         nonlocal expected_value, num_iterations, requests_processed
-        nonlocal received_expected_values
+        nonlocal received_expected_values, requests_received
 
         value = request.data()
         response = provizio_dds.Int32()
@@ -93,8 +103,10 @@ def main() -> int:
                 received_expected_values = False
             expected_value += 1
             num_iterations -= 1
-            if requests_processed:
-                condition_variable.notify_all()
+            # Notify on EVERY request, not only the last: the wait below watches for progress
+            # to distinguish "slow" from "stopped".
+            requests_received += 1
+            condition_variable.notify_all()
 
         print(f"{log_prefix}{_timestamp()}Responding value: {response.data()}")
         return response
@@ -112,12 +124,18 @@ def main() -> int:
     simulated_request_processing_time_sec=0.25
     try:
         with condition_variable:
-            finished = condition_variable.wait_for(
-                lambda: requests_processed, timeout=wait_timeout
-            )
-        if not finished:
-            print(f"{log_prefix}{_timestamp()}Timeout waiting for request")
-            return 1
+            while not requests_processed:
+                received_before_wait = requests_received
+                if not condition_variable.wait_for(
+                    lambda: requests_processed or requests_received != received_before_wait,
+                    timeout=idle_timeout,
+                ):
+                    print(
+                        f"{log_prefix}{_timestamp()}Timeout waiting for request "
+                        f"(none received in the last {idle_timeout}s; "
+                        f"{requests_received} received in total)"
+                    )
+                    return 1
 
         if not received_expected_values:
             return 1

--- a/test/request_response/CMakeLists.txt
+++ b/test/request_response/CMakeLists.txt
@@ -129,5 +129,34 @@ else()
         PROPERTIES TIMEOUT 30)
 endif()
 
+# ---------------------------------------------------------------------------------------
+# Test isolation: ctest entries that share a DDS service/topic name must not run at once.
+#
+# Several entries below reuse the SAME service name on the SAME domain (14) -- by design,
+# since they reuse the same service and client binaries. That is fine when they run one at a
+# time, which is how CI runs them (`ctest` with no -j), but not under `ctest -j`: every
+# client's request then reaches every service, so a service fills its request quota from a
+# FOREIGN test's requests and exits before the paired client is done, and bounded request
+# queues start dropping ("The service requests queue is full!"). Measured before this lock:
+# 6-7 of the 9 request/response entries failed at -j 8; none failed run individually.
+#
+# RESOURCE_LOCK makes ctest serialise exactly the entries that share a name, leaving every
+# other test free to run alongside them. The alternative -- giving each entry its own topic
+# name or domain -- would preserve more parallelism but touches ~20 test programs; the
+# reliability tests already do it that way (a per-test postfix plus a per-iteration domain)
+# if a future test needs it.
+# ---------------------------------------------------------------------------------------
+set_tests_properties(
+    request_response
+    request_response_concurrent_requests_serial_service
+    request_response_service_client
+    request_response_concurrent_requests_service_client
+    request_response_concurrent_service_client
+    PROPERTIES RESOURCE_LOCK provizio_dds_test_request_response)
+set_tests_properties(
+    request_response_ignore
+    request_response_ignore_async
+    PROPERTIES RESOURCE_LOCK provizio_dds_test_request_response_ignore)
+
 # Scale every test TIMEOUT in this directory when a sanitizer is active (no-op otherwise).
 provizio_dds_scale_test_timeouts()

--- a/test/request_response/request_response_service/request_response_reliability_service.cpp
+++ b/test/request_response/request_response_service/request_response_reliability_service.cpp
@@ -72,7 +72,16 @@ int main(int argc, char *argv[])
         (argc > 4)
             ? static_cast<provizio::dds::DomainId_t>(base_domain_id + (std::atoi(argv[4]) % domain_range))  // NOLINT
             : 14;  // NOLINT: OK in a unit test
-    const std::chrono::seconds wait_timeout{num_iterations * 3 + 30};
+    // Deadline on IDLENESS, not on total time. This service is a passive responder: its job is
+    // to notice a client that has STOPPED, not to cap how long a slow machine may take to work
+    // through the iterations. The former budget (num_iterations * 3 + 30) was sized at almost
+    // exactly the per-iteration cost the slowest CI runners actually achieve — a jetson-20.04
+    // run was observed at 412.8 s of its 414 s budget by iteration 120 of 128 — so it failed on
+    // machine speed rather than on anything this test is about. Waiting instead for the gap
+    // BETWEEN requests keeps the regression signal (a client that dies or hangs is still caught,
+    // within a bounded time) while being indifferent to how slow the host is. The ctest TIMEOUT
+    // bounds the whole run regardless.
+    constexpr std::chrono::seconds idle_timeout{60};
 
     const std::string log_prefix = "request_response_reliability_service" + test_name_postfix + ": ";
     const std::string service_name{"provizio_dds_test_request_response_reliability" + test_name_postfix};
@@ -88,6 +97,8 @@ int main(int argc, char *argv[])
 
     std::mutex mutex;
     std::condition_variable condition_variable;
+    // Counts every request handled, so the wait below can tell a slow client from a dead one.
+    std::uint64_t requests_received = 0;
     bool requests_processed = false;
     bool received_expected_values = true;
 
@@ -113,10 +124,10 @@ int main(int argc, char *argv[])
             ++expected_value;
             --num_iterations;
 
-            if (requests_processed)
-            {
-                condition_variable.notify_all();
-            }
+            // Notify on EVERY request, not only the last: the wait below watches for progress
+            // to distinguish "slow" from "stopped".
+            ++requests_received;
+            condition_variable.notify_all();
 
             std::cout << log_prefix << timestamp() << "Responding value: " << response.data() << '\n';
 
@@ -124,10 +135,16 @@ int main(int argc, char *argv[])
         });
 
     std::unique_lock<std::mutex> lock{mutex};
-    if (!condition_variable.wait_for(lock, wait_timeout, [&]() { return requests_processed; }))
+    while (!requests_processed)
     {
-        std::cerr << log_prefix << timestamp() << "Timeout waiting for request" << '\n';
-        return 1;
+        const auto received_before_wait = requests_received;
+        if (!condition_variable.wait_for(
+                lock, idle_timeout, [&]() { return requests_processed || requests_received != received_before_wait; }))
+        {
+            std::cerr << log_prefix << timestamp() << "Timeout waiting for request (none received in the last "
+                      << idle_timeout.count() << "s; " << requests_received << " received in total)" << '\n';
+            return 1;
+        }
     }
 
     if (!received_expected_values)

--- a/test/request_response_concurrent/CMakeLists.txt
+++ b/test/request_response_concurrent/CMakeLists.txt
@@ -27,4 +27,9 @@ else()
 endif()
 
 # Scale every test TIMEOUT in this directory when a sanitizer is active (no-op otherwise).
+# Shares the "provizio_dds_test_request_response" service name with the entries in
+# test/request_response/, so it takes the same lock (see the note there).
+set_tests_properties(request_response_concurrent
+    PROPERTIES RESOURCE_LOCK provizio_dds_test_request_response)
+
 provizio_dds_scale_test_timeouts()

--- a/test/ros_interop/CMakeLists.txt
+++ b/test/ros_interop/CMakeLists.txt
@@ -82,8 +82,11 @@ if(ENABLE_ROS_TESTS)
                 "\"$<TARGET_FILE:ros_interop_request>\""
             )
             # Same as subscriber/publisher above: interop with the native ROS 2 node needs the default transport.
+            # Both entries use the same service name, and both run with the loopback profile
+            # cleared (above) so they are not even confined to localhost -- serialise them.
             set_tests_properties(ros_interop_service ros_interop_request
-                PROPERTIES ENVIRONMENT "FASTDDS_DEFAULT_PROFILES_FILE=")
+                PROPERTIES ENVIRONMENT "FASTDDS_DEFAULT_PROFILES_FILE="
+                           RESOURCE_LOCK provizio_dds_test_ros_interop)
         else(RMW_FASTRPS_VERSION_RETURN_CODE EQUAL 0 AND RMW_FASTRPS_VERSION VERSION_GREATER_EQUAL "8.4.0")
             message(WARNING "ROS2 Jazzy+ is required for ROS Interop Request/Response but ROS 2 $ENV{ROS_DISTRO} is sourced. Appropriate tests will be skipped.")
         endif(RMW_FASTRPS_VERSION_RETURN_CODE EQUAL 0 AND RMW_FASTRPS_VERSION VERSION_GREATER_EQUAL "8.4.0")


### PR DESCRIPTION
Stacked on #55 (shares its branch as a base so the diff stays reviewable; GitHub retargets to `develop` when #55 merges). Nothing here touches library code — it is all tests, CI scripts and images.

Each of the four causes was traced to root rather than absorbed by a bigger timeout or a blanket retry, and **none of them was a defect in the functionality under test**.

## 1. Cross-test interference in the request/response suite

Six ctest entries reuse the same service name `provizio_dds_test_request_response` on the same domain, and two more share the `_ignore` one — they reuse the same service and client programs, so they always have. Fine one at a time (how CI runs them: `ctest` with no `-j`), but under `ctest -j` every client's request reaches every service:

```
[provizio_dds] The service requests queue is full! A request will be dropped.   ← 4 clients, one 5-deep queue
request_response_ignore_service: Successfully sent all the responses            ← quota filled by a FOREIGN test
request_response_ignore_client: Timeout! Expected response for request 5        ← so it exited before ours arrived
```

**Measured: 6–7 of the 9 entries failed at `-j 8`; none failed individually.** The library is doing exactly what it should — several services on one service name means several responders.

Fixed with a `RESOURCE_LOCK` per shared name, so ctest serialises exactly the colliding entries and everything else still runs alongside them. `ros_interop_service`/`ros_interop_request` get one too — same shared name, and they run with the loopback profile cleared, so they are not even confined to localhost.

## 2. The reliability service's deadline measured the wrong thing

Budget was `num_iterations * 3 + 30` = 414 s — almost exactly the per-iteration cost the slowest runners achieve. A jetson-20.04 run was observed at **412.8 s of its 414 s budget by iteration 120 of 128**. It failed on machine speed, not on anything the test is about. This is the recurring CI failure of this suite.

A passive responder's deadline should detect a client that has *stopped*, not cap how long a slow machine may take. Both the C++ and Python services now wait for the gap *between* requests: 60 s of silence fails, arbitrary slowness does not. A dead or hung client is still caught, and the ctest TIMEOUT still bounds the run.

## 3. apt had no retries

~30 bare `apt` calls in `install_dependencies.sh`, re-run from scratch inside the congested-network Docker image on every CI run — the project's largest apt surface. Now routed through a wrapper applying `Acquire::Retries` and `DPkg::Lock::Timeout` (ignored by apt < 1.9 on 18.04) plus backoff with a package-list refresh between attempts. Calls whose failure is an expected outcome the caller handles keep the options but skip the retries.

## 4. Docker: infrastructure separated from the test result, and Docker Hub off the critical path

`docker compose up --build` conflated *build* (infrastructure, safely retryable) with the *subscriber exit code* (the result, which must never be retried away). Build now runs once with retries; the test runs `--no-build`.

A registry rate limit is deliberately **not** retried — Docker Hub answers a pull past its unauthenticated per-IP limit with an immediate HTTP 429 and resets on an hourly window, so no backoff a build can apply outlasts it. It is detected and reported with what to do instead.

Better still, it should not arise: the base image and the `ros:*` job containers now come from `mirror.gcr.io`, a pull-through cache serving byte-identical Docker Hub content, not subject to those limits, needing no credentials. Self-hosted runners share one egress IP across every concurrent job in the org — exactly the shape that hits the limit. Both are overridable (`BASE_IMAGE`, and the `CONTAINER_REGISTRY_PREFIX` variable) to point at a registry the runners authenticate against.

## Test plan

- Full ctest at `-j 6`: repeatedly **123/123**, where before the change nearly every run lost one test and `-j 8` lost five or six.
- The previously-failing scenario (`-R request_response -E reliability -j 8`): **9/9, three times**, up from 3/9 and 2/9.
- Both reliability tests pass on their normal path (420 s and 230 s).
- Retry/fast-fail logic exercised against simulated docker failures: rate limit → fails immediately without retrying; transient → succeeds on the retry; genuinely broken build → gives up rather than looping, so a real breakage is never masked.
- `mirror.gcr.io/library/ubuntu:22.04` and `mirror.gcr.io/library/ros:{humble,jazzy,lyrical}` verified pullable; compose file validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)